### PR TITLE
Harden execution budget validation

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -102,6 +102,16 @@ export interface SupervisorEscalation<I, O> {
   resolve(context: WorkflowContext): Promise<O>;
 }
 
+export class InvalidBudgetValueError extends Error {
+  constructor(
+    public readonly field: keyof ExecutionBudget | keyof ExecutionUsage,
+    public readonly value: number,
+  ) {
+    super(`Invalid execution budget value for ${field}: ${String(value)}`);
+    this.name = "InvalidBudgetValueError";
+  }
+}
+
 export class BudgetExceededError extends Error {
   constructor(
     public readonly dimension: keyof ExecutionBudget,
@@ -113,8 +123,45 @@ export class BudgetExceededError extends Error {
   }
 }
 
+function assertFiniteNonNegative(
+  field: keyof ExecutionBudget | keyof ExecutionUsage,
+  value: number,
+): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new InvalidBudgetValueError(field, value);
+  }
+}
+
 export function assertWithinBudget(context: WorkflowContext): void {
   const { budget, usage } = context;
+
+  const budgetValues: ReadonlyArray<readonly [keyof ExecutionBudget, number]> = [
+    ["maxToolCalls", budget.maxToolCalls],
+    ["maxRetries", budget.maxRetries],
+    ["maxIterations", budget.maxIterations],
+    ["maxTokens", budget.maxTokens],
+    ["maxDurationMs", budget.maxDurationMs],
+    ["maxCostUsd", budget.maxCostUsd],
+  ];
+
+  const usageValues: ReadonlyArray<readonly [keyof ExecutionUsage, number]> = [
+    ["toolCalls", usage.toolCalls],
+    ["retries", usage.retries],
+    ["iterations", usage.iterations],
+    ["inputTokens", usage.inputTokens],
+    ["outputTokens", usage.outputTokens],
+    ["durationMs", usage.durationMs],
+    ["costUsd", usage.costUsd],
+  ];
+
+  for (const [field, value] of budgetValues) {
+    assertFiniteNonNegative(field, value);
+  }
+
+  for (const [field, value] of usageValues) {
+    assertFiniteNonNegative(field, value);
+  }
+
   const checks: ReadonlyArray<
     readonly [keyof ExecutionBudget, number, number]
   > = [

--- a/packages/contracts/test/budget.test.ts
+++ b/packages/contracts/test/budget.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   assertWithinBudget,
   BudgetExceededError,
+  InvalidBudgetValueError,
   type WorkflowContext,
 } from "../src/index.js";
 
-function context(overrides: Partial<WorkflowContext["usage"]> = {}): WorkflowContext {
+function context(
+  usageOverrides: Partial<WorkflowContext["usage"]> = {},
+  budgetOverrides: Partial<WorkflowContext["budget"]> = {},
+): WorkflowContext {
   return {
     executionId: "exec-1",
     workflowId: "test-workflow",
@@ -19,6 +23,7 @@ function context(overrides: Partial<WorkflowContext["usage"]> = {}): WorkflowCon
       maxTokens: 10_000,
       maxDurationMs: 60_000,
       maxCostUsd: 1,
+      ...budgetOverrides,
     },
     usage: {
       toolCalls: 0,
@@ -28,14 +33,14 @@ function context(overrides: Partial<WorkflowContext["usage"]> = {}): WorkflowCon
       outputTokens: 0,
       durationMs: 0,
       costUsd: 0,
-      ...overrides,
+      ...usageOverrides,
     },
     metadata: {},
   };
 }
 
 describe("assertWithinBudget", () => {
-  it("accepts usage at or below every configured limit", () => {
+  it("accepts usage exactly at every configured limit", () => {
     expect(() =>
       assertWithinBudget(
         context({
@@ -51,15 +56,46 @@ describe("assertWithinBudget", () => {
     ).not.toThrow();
   });
 
-  it("fails closed when a limit is exceeded", () => {
-    expect(() => assertWithinBudget(context({ toolCalls: 11 }))).toThrow(
+  it.each([
+    ["maxToolCalls", { toolCalls: 11 }],
+    ["maxRetries", { retries: 3 }],
+    ["maxIterations", { iterations: 6 }],
+    ["maxTokens", { inputTokens: 5_000, outputTokens: 5_001 }],
+    ["maxDurationMs", { durationMs: 60_001 }],
+    ["maxCostUsd", { costUsd: 1.01 }],
+  ] as const)("fails closed when %s is exceeded", (dimension, usage) => {
+    expect(() => assertWithinBudget(context(usage))).toThrow(
       BudgetExceededError,
     );
+    expect(() => assertWithinBudget(context(usage))).toThrow(dimension);
   });
 
-  it("combines input and output tokens for token enforcement", () => {
-    expect(() =>
-      assertWithinBudget(context({ inputTokens: 8_000, outputTokens: 2_001 })),
-    ).toThrow(/maxTokens/);
+  it.each([
+    ["toolCalls", { toolCalls: -1 }],
+    ["retries", { retries: Number.NaN }],
+    ["iterations", { iterations: Number.POSITIVE_INFINITY }],
+    ["inputTokens", { inputTokens: Number.NEGATIVE_INFINITY }],
+    ["outputTokens", { outputTokens: -1 }],
+    ["durationMs", { durationMs: Number.NaN }],
+    ["costUsd", { costUsd: Number.POSITIVE_INFINITY }],
+  ] as const)("rejects invalid usage field %s", (field, usage) => {
+    expect(() => assertWithinBudget(context(usage))).toThrow(
+      InvalidBudgetValueError,
+    );
+    expect(() => assertWithinBudget(context(usage))).toThrow(field);
+  });
+
+  it.each([
+    ["maxToolCalls", { maxToolCalls: -1 }],
+    ["maxRetries", { maxRetries: Number.NaN }],
+    ["maxIterations", { maxIterations: Number.POSITIVE_INFINITY }],
+    ["maxTokens", { maxTokens: Number.NEGATIVE_INFINITY }],
+    ["maxDurationMs", { maxDurationMs: -1 }],
+    ["maxCostUsd", { maxCostUsd: Number.NaN }],
+  ] as const)("rejects invalid budget field %s", (field, budget) => {
+    expect(() => assertWithinBudget(context({}, budget))).toThrow(
+      InvalidBudgetValueError,
+    );
+    expect(() => assertWithinBudget(context({}, budget))).toThrow(field);
   });
 });


### PR DESCRIPTION
## Summary
- reject non-finite and negative budget limits before comparison
- reject non-finite and negative observed usage before comparison
- add dimension-by-dimension overage coverage
- add invalid-value coverage for every budget and usage field
- preserve exact-boundary acceptance behavior

## Evidence
- Source and tests are isolated on `sprint/issue-9-budget-hardening`.
- GitHub Actions is expected to run the existing Contracts workflow on this PR.

## Remaining issue #9 work
- generate and commit `pnpm-lock.yaml` with pnpm 10.14.0
- switch CI to `pnpm install --frozen-lockfile`

Closes part of #9; does not close the issue until reproducible install evidence is complete.