### PR TITLE
Add provider-neutral benchmark scorecards and bounded refinement

### DIFF
--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -17,6 +17,7 @@
     "./external-effect-ownership-loss-context": "./src/external-effect-ownership-loss-context.ts",
     "./persistence-uncertainty-recovery-selection": "./src/persistence-uncertainty-recovery-selection.ts",
     "./persistence-uncertainty-repository": "./src/persistence-uncertainty-repository.ts",
+    "./provider-neutral-benchmark": "./src/provider-neutral-benchmark.ts",
     "./self-improvement-patch-generator": "./src/self-improvement-patch-generator.ts",
     "./task-entrypoint": "./src/task-entrypoint.ts",
     "./resumable-task-entrypoint": "./src/resumable-task-entrypoint.ts",

--- a/packages/event-store/src/__tests__/provider-neutral-benchmark.test.ts
+++ b/packages/event-store/src/__tests__/provider-neutral-benchmark.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { EvaluationResult, WorkflowContext } from "@atlantis/contracts";
+import {
+  compareProviderBenchmarkRecords,
+  InvalidBenchmarkEvidenceError,
+  runBoundedBenchmark,
+  type BenchmarkCase,
+  type ProviderBenchmarkRecord,
+} from "../provider-neutral-benchmark.js";
+
+function context(maxIterations: number): WorkflowContext {
+  return {
+    executionId: "exec-benchmark-1",
+    workflowId: "benchmark-workflow",
+    workflowVersion: "1.0.0",
+    userId: "benchmark-user",
+    mode: "workflow",
+    budget: {
+      maxToolCalls: 10,
+      maxRetries: 2,
+      maxIterations,
+      maxTokens: 10_000,
+      maxDurationMs: 60_000,
+      maxCostUsd: 10,
+    },
+    usage: {
+      toolCalls: 0,
+      retries: 0,
+      iterations: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      durationMs: 0,
+      costUsd: 0,
+    },
+    metadata: {},
+  };
+}
+
+function evaluation(score: number, passed = true): EvaluationResult {
+  return {
+    score,
+    passed,
+    reasons: passed ? [] : ["quality threshold not met"],
+    metrics: { quality: score, safety: 1, grounding: 1, toolUse: 1 },
+  };
+}
+
+describe("provider-neutral benchmark", () => {
+  it("scores and refines a coding workflow within the configured iteration bound", async () => {
+    const benchmarkCase: BenchmarkCase<string> = {
+      id: "coding-fix-v1",
+      version: "1",
+      workflowKind: "coding",
+      input: "repair deterministic parser",
+      passThreshold: 0.8,
+    };
+    const scores = [0.6, 0.9];
+    let index = 0;
+
+    const result = await runBoundedBenchmark(
+      benchmarkCase,
+      context(2),
+      { generate: async (input) => `${input}:draft` },
+      { evaluate: async () => evaluation(scores[index++] ?? 0) },
+      { refine: async (_input, prior) => `${prior}:refined` },
+    );
+
+    expect(result.workflowKind).toBe("coding");
+    expect(result.passed).toBe(true);
+    expect(result.exhausted).toBe(false);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.final.scorecard.score).toBe(0.9);
+  });
+
+  it("produces deterministic scorecards for a conversational workflow", async () => {
+    const result = await runBoundedBenchmark(
+      {
+        id: "conversation-grounded-v1",
+        version: "1",
+        workflowKind: "conversation",
+        input: "summarize supplied evidence",
+        passThreshold: 0.85,
+      },
+      context(1),
+      { generate: async () => "grounded response" },
+      { evaluate: async () => evaluation(0.91) },
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.final.scorecard.metrics).toEqual({
+      quality: 0.91,
+      safety: 1,
+      grounding: 1,
+      toolUse: 1,
+    });
+  });
+
+  it("fails closed when the score remains below threshold and the iteration budget is exhausted", async () => {
+    const result = await runBoundedBenchmark(
+      {
+        id: "coding-exhaustion-v1",
+        version: "1",
+        workflowKind: "coding",
+        input: "fix",
+        passThreshold: 0.9,
+      },
+      context(2),
+      { generate: async () => "draft" },
+      { evaluate: async () => evaluation(0.5) },
+      { refine: async (_input, prior) => `${prior}:retry` },
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.attempts).toHaveLength(2);
+  });
+
+  it("does not convert an evaluator failure into a passing threshold result", async () => {
+    const result = await runBoundedBenchmark(
+      {
+        id: "conversation-evaluator-fail-v1",
+        version: "1",
+        workflowKind: "conversation",
+        input: "answer",
+        passThreshold: 0.8,
+      },
+      context(1),
+      { generate: async () => "response" },
+      { evaluate: async () => evaluation(0.95, false) },
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.final.scorecard.passed).toBe(false);
+  });
+
+  it("keeps missing real-provider evidence explicitly gated and unable to satisfy acceptance", () => {
+    const mock: ProviderBenchmarkRecord = {
+      providerId: "deterministic-mock",
+      providerKind: "mock",
+      evidenceState: "executed",
+      caseId: "coding-fix-v1",
+      caseVersion: "1",
+      workflowKind: "coding",
+      scorecard: {
+        score: 0.9,
+        passed: true,
+        threshold: 0.8,
+        reasons: [],
+        metrics: { quality: 0.9 },
+      },
+      measurement: { latencyMs: 1, inputTokens: 10, outputTokens: 20, costUsd: 0 },
+    };
+    const gatedReal: ProviderBenchmarkRecord = {
+      providerId: "unselected-real-provider",
+      providerKind: "real",
+      evidenceState: "gated-not-executed",
+      caseId: "coding-fix-v1",
+      caseVersion: "1",
+      workflowKind: "coding",
+      gateReason: "provider/model/credential authority not selected",
+    };
+
+    expect(compareProviderBenchmarkRecords(mock, gatedReal)).toMatchObject({
+      status: "real-provider-gated",
+      acceptanceSatisfied: false,
+    });
+  });
+
+  it("rejects fabricated measurements on gated real-provider evidence", () => {
+    const mock: ProviderBenchmarkRecord = {
+      providerId: "deterministic-mock",
+      providerKind: "mock",
+      evidenceState: "executed",
+      caseId: "conversation-v1",
+      caseVersion: "1",
+      workflowKind: "conversation",
+      scorecard: { score: 1, passed: true, threshold: 0.8, reasons: [], metrics: {} },
+      measurement: { latencyMs: 1 },
+    };
+    const invalidReal = {
+      providerId: "unselected-real-provider",
+      providerKind: "real" as const,
+      evidenceState: "gated-not-executed" as const,
+      caseId: "conversation-v1",
+      caseVersion: "1",
+      workflowKind: "conversation" as const,
+      gateReason: "not authorized",
+      measurement: { latencyMs: 1 },
+    };
+
+    expect(() => compareProviderBenchmarkRecords(mock, invalidReal)).toThrow(
+      InvalidBenchmarkEvidenceError,
+    );
+  });
+});

--- a/packages/event-store/src/__tests__/provider-neutral-benchmark.test.ts
+++ b/packages/event-store/src/__tests__/provider-neutral-benchmark.test.ts
@@ -115,6 +115,34 @@ describe("provider-neutral benchmark", () => {
     expect(result.attempts).toHaveLength(2);
   });
 
+  it("does not execute generation after the shared iteration budget is already exhausted", async () => {
+    const exhaustedContext = context(1);
+    exhaustedContext.usage.iterations = 1;
+    let generated = false;
+
+    await expect(
+      runBoundedBenchmark(
+        {
+          id: "budget-exhausted-v1",
+          version: "1",
+          workflowKind: "coding",
+          input: "fix",
+          passThreshold: 0.8,
+        },
+        exhaustedContext,
+        {
+          generate: async () => {
+            generated = true;
+            return "must-not-run";
+          },
+        },
+        { evaluate: async () => evaluation(1) },
+      ),
+    ).rejects.toThrow("no benchmark iteration budget remains");
+
+    expect(generated).toBe(false);
+  });
+
   it("does not convert an evaluator failure into a passing threshold result", async () => {
     const result = await runBoundedBenchmark(
       {

--- a/packages/event-store/src/provider-neutral-benchmark.ts
+++ b/packages/event-store/src/provider-neutral-benchmark.ts
@@ -136,6 +136,14 @@ export function normalizeBenchmarkScorecard(
   });
 }
 
+function reserveIteration(context: WorkflowContext): void {
+  if (context.usage.iterations >= context.budget.maxIterations) {
+    throw new InvalidBenchmarkEvidenceError("no benchmark iteration budget remains.");
+  }
+  context.usage.iterations += 1;
+  assertWithinBudget(context);
+}
+
 export async function runBoundedBenchmark<TInput, TOutput>(
   benchmarkCase: BenchmarkCase<TInput>,
   context: WorkflowContext,
@@ -146,18 +154,20 @@ export async function runBoundedBenchmark<TInput, TOutput>(
   validateCase(benchmarkCase);
   assertWithinBudget(context);
 
-  const maxAttempts = context.budget.maxIterations;
-  if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1) {
+  if (!Number.isSafeInteger(context.budget.maxIterations) || context.budget.maxIterations < 1) {
     throw new InvalidBenchmarkEvidenceError("context.budget.maxIterations must allow at least one attempt.");
   }
 
+  const maxAttempts = context.budget.maxIterations - context.usage.iterations;
+  if (maxAttempts < 1) {
+    throw new InvalidBenchmarkEvidenceError("no benchmark iteration budget remains.");
+  }
+
   const attempts: BenchmarkAttempt<TOutput>[] = [];
+  reserveIteration(context);
   let output = await generator.generate(benchmarkCase.input, context);
 
   for (let iteration = 1; iteration <= maxAttempts; iteration += 1) {
-    context.usage.iterations += 1;
-    assertWithinBudget(context);
-
     const evaluation = await evaluator.evaluate(output, context);
     const scorecard = normalizeBenchmarkScorecard(evaluation, benchmarkCase.passThreshold);
     const attempt = Object.freeze({ iteration, output, scorecard });
@@ -187,6 +197,7 @@ export async function runBoundedBenchmark<TInput, TOutput>(
       });
     }
 
+    reserveIteration(context);
     output = await refiner.refine(benchmarkCase.input, output, evaluation, context);
   }
 

--- a/packages/event-store/src/provider-neutral-benchmark.ts
+++ b/packages/event-store/src/provider-neutral-benchmark.ts
@@ -1,0 +1,280 @@
+import {
+  assertWithinBudget,
+  type EvaluationResult,
+  type Evaluator,
+  type WorkflowContext,
+} from "@atlantis/contracts";
+
+export type BenchmarkWorkflowKind = "coding" | "conversation";
+
+export interface BenchmarkCase<TInput> {
+  readonly id: string;
+  readonly version: string;
+  readonly workflowKind: BenchmarkWorkflowKind;
+  readonly input: TInput;
+  readonly passThreshold: number;
+}
+
+export interface BenchmarkMeasurement {
+  readonly latencyMs: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly costUsd?: number;
+}
+
+export interface BenchmarkScorecard {
+  readonly score: number;
+  readonly passed: boolean;
+  readonly threshold: number;
+  readonly reasons: readonly string[];
+  readonly metrics: Readonly<Record<string, number>>;
+}
+
+export interface BenchmarkAttempt<TOutput> {
+  readonly iteration: number;
+  readonly output: TOutput;
+  readonly scorecard: BenchmarkScorecard;
+}
+
+export interface BoundedBenchmarkResult<TOutput> {
+  readonly caseId: string;
+  readonly caseVersion: string;
+  readonly workflowKind: BenchmarkWorkflowKind;
+  readonly attempts: readonly BenchmarkAttempt<TOutput>[];
+  readonly final: BenchmarkAttempt<TOutput>;
+  readonly passed: boolean;
+  readonly exhausted: boolean;
+}
+
+export interface BenchmarkGenerator<TInput, TOutput> {
+  generate(input: TInput, context: WorkflowContext): Promise<TOutput>;
+}
+
+export interface BenchmarkRefiner<TInput, TOutput> {
+  refine(
+    input: TInput,
+    priorOutput: TOutput,
+    evaluation: EvaluationResult,
+    context: WorkflowContext,
+  ): Promise<TOutput>;
+}
+
+export type ProviderBenchmarkEvidenceState = "executed" | "gated-not-executed";
+
+export interface ProviderBenchmarkRecord {
+  readonly providerId: string;
+  readonly providerKind: "mock" | "real";
+  readonly evidenceState: ProviderBenchmarkEvidenceState;
+  readonly modelId?: string;
+  readonly caseId: string;
+  readonly caseVersion: string;
+  readonly workflowKind: BenchmarkWorkflowKind;
+  readonly scorecard?: BenchmarkScorecard;
+  readonly measurement?: BenchmarkMeasurement;
+  readonly gateReason?: string;
+}
+
+export interface ProviderComparisonReport {
+  readonly caseId: string;
+  readonly caseVersion: string;
+  readonly workflowKind: BenchmarkWorkflowKind;
+  readonly mock: ProviderBenchmarkRecord;
+  readonly real: ProviderBenchmarkRecord;
+  readonly status: "complete" | "real-provider-gated";
+  readonly acceptanceSatisfied: boolean;
+  readonly scoreDelta?: number;
+}
+
+export class InvalidBenchmarkEvidenceError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "InvalidBenchmarkEvidenceError";
+  }
+}
+
+function requireNonEmpty(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new InvalidBenchmarkEvidenceError(`${field} must be non-empty.`);
+  }
+}
+
+function requireFiniteNonNegative(value: number, field: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new InvalidBenchmarkEvidenceError(`${field} must be finite and non-negative.`);
+  }
+}
+
+function requireProbability(value: number, field: string): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new InvalidBenchmarkEvidenceError(`${field} must be between 0 and 1.`);
+  }
+}
+
+function validateCase<TInput>(benchmarkCase: BenchmarkCase<TInput>): void {
+  requireNonEmpty(benchmarkCase.id, "case.id");
+  requireNonEmpty(benchmarkCase.version, "case.version");
+  requireProbability(benchmarkCase.passThreshold, "case.passThreshold");
+}
+
+export function normalizeBenchmarkScorecard(
+  evaluation: EvaluationResult,
+  threshold: number,
+): BenchmarkScorecard {
+  requireProbability(threshold, "threshold");
+  requireProbability(evaluation.score, "evaluation.score");
+  for (const [name, value] of Object.entries(evaluation.metrics)) {
+    requireNonEmpty(name, "evaluation metric name");
+    requireFiniteNonNegative(value, `evaluation.metrics.${name}`);
+  }
+
+  return Object.freeze({
+    score: evaluation.score,
+    passed: evaluation.passed && evaluation.score >= threshold,
+    threshold,
+    reasons: Object.freeze([...evaluation.reasons]),
+    metrics: Object.freeze({ ...evaluation.metrics }),
+  });
+}
+
+export async function runBoundedBenchmark<TInput, TOutput>(
+  benchmarkCase: BenchmarkCase<TInput>,
+  context: WorkflowContext,
+  generator: BenchmarkGenerator<TInput, TOutput>,
+  evaluator: Evaluator<TOutput>,
+  refiner?: BenchmarkRefiner<TInput, TOutput>,
+): Promise<BoundedBenchmarkResult<TOutput>> {
+  validateCase(benchmarkCase);
+  assertWithinBudget(context);
+
+  const maxAttempts = context.budget.maxIterations;
+  if (!Number.isSafeInteger(maxAttempts) || maxAttempts < 1) {
+    throw new InvalidBenchmarkEvidenceError("context.budget.maxIterations must allow at least one attempt.");
+  }
+
+  const attempts: BenchmarkAttempt<TOutput>[] = [];
+  let output = await generator.generate(benchmarkCase.input, context);
+
+  for (let iteration = 1; iteration <= maxAttempts; iteration += 1) {
+    context.usage.iterations += 1;
+    assertWithinBudget(context);
+
+    const evaluation = await evaluator.evaluate(output, context);
+    const scorecard = normalizeBenchmarkScorecard(evaluation, benchmarkCase.passThreshold);
+    const attempt = Object.freeze({ iteration, output, scorecard });
+    attempts.push(attempt);
+
+    if (scorecard.passed) {
+      return Object.freeze({
+        caseId: benchmarkCase.id,
+        caseVersion: benchmarkCase.version,
+        workflowKind: benchmarkCase.workflowKind,
+        attempts: Object.freeze([...attempts]),
+        final: attempt,
+        passed: true,
+        exhausted: false,
+      });
+    }
+
+    if (iteration === maxAttempts || refiner === undefined) {
+      return Object.freeze({
+        caseId: benchmarkCase.id,
+        caseVersion: benchmarkCase.version,
+        workflowKind: benchmarkCase.workflowKind,
+        attempts: Object.freeze([...attempts]),
+        final: attempt,
+        passed: false,
+        exhausted: iteration === maxAttempts,
+      });
+    }
+
+    output = await refiner.refine(benchmarkCase.input, output, evaluation, context);
+  }
+
+  throw new InvalidBenchmarkEvidenceError("bounded benchmark terminated without a final attempt.");
+}
+
+function validateExecutedRecord(record: ProviderBenchmarkRecord): void {
+  if (record.scorecard === undefined || record.measurement === undefined) {
+    throw new InvalidBenchmarkEvidenceError("executed provider evidence requires scorecard and measurement.");
+  }
+  requireFiniteNonNegative(record.measurement.latencyMs, "measurement.latencyMs");
+  if (record.measurement.inputTokens !== undefined) {
+    requireFiniteNonNegative(record.measurement.inputTokens, "measurement.inputTokens");
+  }
+  if (record.measurement.outputTokens !== undefined) {
+    requireFiniteNonNegative(record.measurement.outputTokens, "measurement.outputTokens");
+  }
+  if (record.measurement.costUsd !== undefined) {
+    requireFiniteNonNegative(record.measurement.costUsd, "measurement.costUsd");
+  }
+}
+
+function validateProviderRecord(record: ProviderBenchmarkRecord): void {
+  requireNonEmpty(record.providerId, "providerId");
+  requireNonEmpty(record.caseId, "caseId");
+  requireNonEmpty(record.caseVersion, "caseVersion");
+  if (record.evidenceState === "executed") {
+    validateExecutedRecord(record);
+    return;
+  }
+  if (record.providerKind !== "real") {
+    throw new InvalidBenchmarkEvidenceError("only a real-provider record may be gated-not-executed.");
+  }
+  if (record.scorecard !== undefined || record.measurement !== undefined) {
+    throw new InvalidBenchmarkEvidenceError("gated real-provider evidence must not fabricate scorecard or measurement data.");
+  }
+  if (record.gateReason === undefined || record.gateReason.trim().length === 0) {
+    throw new InvalidBenchmarkEvidenceError("gated real-provider evidence requires a gateReason.");
+  }
+}
+
+export function compareProviderBenchmarkRecords(
+  mock: ProviderBenchmarkRecord,
+  real: ProviderBenchmarkRecord,
+): ProviderComparisonReport {
+  validateProviderRecord(mock);
+  validateProviderRecord(real);
+
+  if (mock.providerKind !== "mock" || mock.evidenceState !== "executed") {
+    throw new InvalidBenchmarkEvidenceError("mock benchmark evidence must be an executed mock-provider record.");
+  }
+  if (real.providerKind !== "real") {
+    throw new InvalidBenchmarkEvidenceError("real benchmark evidence must identify a real provider.");
+  }
+  if (
+    mock.caseId !== real.caseId ||
+    mock.caseVersion !== real.caseVersion ||
+    mock.workflowKind !== real.workflowKind
+  ) {
+    throw new InvalidBenchmarkEvidenceError("provider benchmark records must describe the same versioned case.");
+  }
+
+  if (real.evidenceState === "gated-not-executed") {
+    return Object.freeze({
+      caseId: mock.caseId,
+      caseVersion: mock.caseVersion,
+      workflowKind: mock.workflowKind,
+      mock,
+      real,
+      status: "real-provider-gated",
+      acceptanceSatisfied: false,
+    });
+  }
+
+  const mockScore = mock.scorecard?.score;
+  const realScore = real.scorecard?.score;
+  if (mockScore === undefined || realScore === undefined) {
+    throw new InvalidBenchmarkEvidenceError("executed provider records require scorecards.");
+  }
+
+  return Object.freeze({
+    caseId: mock.caseId,
+    caseVersion: mock.caseVersion,
+    workflowKind: mock.workflowKind,
+    mock,
+    real,
+    status: "complete",
+    acceptanceSatisfied: mock.scorecard?.passed === true && real.scorecard?.passed === true,
+    scoreDelta: realScore - mockScore,
+  });
+}


### PR DESCRIPTION
Implements bounded work packet #23 for parent Issue #6 from canonical base `895f0facb8e79f901ac3ed8a66ffa59a72c65fa9`.

Scope:
- provider-neutral coding/conversation benchmark case contract;
- normalized deterministic scorecards using existing `EvaluationResult` / `Evaluator`;
- bounded generate/evaluate/refine loop using existing `WorkflowContext` execution budgets;
- provider-comparison record/report contract;
- explicit `gated-not-executed` real-provider evidence state that cannot satisfy acceptance or carry fabricated score/measurement evidence;
- deterministic tests for coding refinement success, conversation scorecard success, iteration exhaustion, evaluator fail-closed behavior, gated real-provider reporting, and fabricated gated evidence rejection.

Independent review found and corrected a pre-integration budget-ordering defect: initial generation could occur before reserving iteration budget. Current head `87aa3c6a564cf74f248f667df457f7f6475286df` reserves shared iteration budget before generation/refinement and includes a regression proof that generation is never invoked when the shared iteration budget is already exhausted.

This PR deliberately does **not** select a real provider/model, request credentials, enable network/spend, or claim parent #6 complete. It targets the sprint integration branch and stops for focused-head verification before integration.

Refs #23, #6, #8.