### PR TITLE
Bind self-improvement operational admission to trusted evidence

### DIFF
--- a/packages/contracts/src/self-improvement-operational-candidate-authorization.ts
+++ b/packages/contracts/src/self-improvement-operational-candidate-authorization.ts
@@ -32,6 +32,18 @@ export interface SelfImprovementOperationalCandidateAuthorization {
   readonly approvals: readonly SelfImprovementOperationalCandidateApproval[];
 }
 
+export interface ExpectedSelfImprovementOperationalCandidateAdmission {
+  readonly candidateId: string;
+  readonly repository: string;
+  readonly baseRevision: string;
+  readonly configurationDigest: string;
+  readonly credentialClass: string;
+  readonly networkBoundary: string;
+  readonly verificationGates: string;
+  readonly decisionEvidence: string;
+  readonly approvalIdentities: Readonly<Record<SelfImprovementOperationalCandidateApprovalRole, string>>;
+}
+
 export class InvalidSelfImprovementOperationalCandidateAuthorizationError extends Error {
   constructor(message: string) {
     super(message);
@@ -50,6 +62,11 @@ const approvalFields = ["role", "approvedBy", "approvedAt"] as const;
 const authorizationFields = [
   ...requiredFields, "executionEnvironment", "featureGateDefault", "authorityBoundary", "approvals",
 ] as const;
+const expectedAdmissionFields = [
+  "candidateId", "repository", "baseRevision", "configurationDigest", "credentialClass", "networkBoundary",
+  "verificationGates", "decisionEvidence", "approvalIdentities",
+] as const;
+const approvalRoles = ["architecture", "operations", "security-network"] as const;
 
 function record(field: string, value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -117,7 +134,7 @@ export function validateSelfImprovementOperationalCandidateAuthorization(
     throw new InvalidSelfImprovementOperationalCandidateAuthorizationError("approvals must be an array");
   }
   const approvals = candidate.approvals.map(approval);
-  for (const role of ["architecture", "operations", "security-network"] as const) {
+  for (const role of approvalRoles) {
     if (approvals.filter((item) => item.role === role).length !== 1) {
       throw new InvalidSelfImprovementOperationalCandidateAuthorizationError(`exactly one ${role} approval is required`);
     }
@@ -130,4 +147,68 @@ export function validateSelfImprovementOperationalCandidateAuthorization(
     authorityBoundary: "no-prohibited-authority",
     approvals: Object.freeze(approvals),
   });
+}
+
+function expectedAdmission(value: unknown): Readonly<ExpectedSelfImprovementOperationalCandidateAdmission> {
+  const candidate = record("expectedAdmission", value);
+  rejectUnknown("expectedAdmission", candidate, expectedAdmissionFields);
+  const approvalIdentities = record("expectedAdmission.approvalIdentities", candidate.approvalIdentities);
+  rejectUnknown("expectedAdmission.approvalIdentities", approvalIdentities, approvalRoles);
+
+  const normalizedApprovals = Object.freeze({
+    architecture: nonBlank("expectedAdmission.approvalIdentities.architecture", approvalIdentities.architecture),
+    operations: nonBlank("expectedAdmission.approvalIdentities.operations", approvalIdentities.operations),
+    "security-network": nonBlank("expectedAdmission.approvalIdentities.security-network", approvalIdentities["security-network"]),
+  });
+
+  return Object.freeze({
+    candidateId: nonBlank("expectedAdmission.candidateId", candidate.candidateId),
+    repository: nonBlank("expectedAdmission.repository", candidate.repository),
+    baseRevision: nonBlank("expectedAdmission.baseRevision", candidate.baseRevision),
+    configurationDigest: nonBlank("expectedAdmission.configurationDigest", candidate.configurationDigest),
+    credentialClass: nonBlank("expectedAdmission.credentialClass", candidate.credentialClass),
+    networkBoundary: nonBlank("expectedAdmission.networkBoundary", candidate.networkBoundary),
+    verificationGates: nonBlank("expectedAdmission.verificationGates", candidate.verificationGates),
+    decisionEvidence: nonBlank("expectedAdmission.decisionEvidence", candidate.decisionEvidence),
+    approvalIdentities: normalizedApprovals,
+  });
+}
+
+/**
+ * Binds a structurally valid candidate to independently supplied admission expectations.
+ * Candidate-supplied identity, base/configuration, verification, network, credential, decision, or approver values
+ * cannot substitute for the expected values. This function remains provider/runtime neutral and performs no execution.
+ */
+export function authorizeSelfImprovementOperationalCandidateAdmission(
+  authorization: unknown,
+  expected: unknown,
+): Readonly<SelfImprovementOperationalCandidateAuthorization> {
+  const admitted = validateSelfImprovementOperationalCandidateAuthorization(authorization);
+  const trusted = expectedAdmission(expected);
+
+  const exactBindings = [
+    ["candidateId", admitted.candidateId, trusted.candidateId],
+    ["repository", admitted.repository, trusted.repository],
+    ["baseRevision", admitted.baseRevision, trusted.baseRevision],
+    ["configurationDigest", admitted.configurationDigest, trusted.configurationDigest],
+    ["credentialClass", admitted.credentialClass, trusted.credentialClass],
+    ["networkBoundary", admitted.networkBoundary, trusted.networkBoundary],
+    ["verificationGates", admitted.verificationGates, trusted.verificationGates],
+    ["decisionEvidence", admitted.decisionEvidence, trusted.decisionEvidence],
+  ] as const;
+
+  for (const [field, observed, required] of exactBindings) {
+    if (observed !== required) {
+      throw new InvalidSelfImprovementOperationalCandidateAuthorizationError(`${field} does not match expected admission value`);
+    }
+  }
+
+  for (const role of approvalRoles) {
+    const observed = admitted.approvals.find((item) => item.role === role);
+    if (observed?.approvedBy !== trusted.approvalIdentities[role]) {
+      throw new InvalidSelfImprovementOperationalCandidateAuthorizationError(`${role} approval identity does not match expected admission value`);
+    }
+  }
+
+  return admitted;
 }

--- a/packages/contracts/test/self-improvement-operational-candidate-authorization.test.ts
+++ b/packages/contracts/test/self-improvement-operational-candidate-authorization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   InvalidSelfImprovementOperationalCandidateAuthorizationError,
+  authorizeSelfImprovementOperationalCandidateAdmission,
   validateSelfImprovementOperationalCandidateAuthorization,
 } from "../src/self-improvement-operational-candidate-authorization.js";
 
@@ -37,6 +38,24 @@ function candidate() {
   } as const;
 }
 
+function expectedAdmission() {
+  return {
+    candidateId: "self-improvement-candidate-1",
+    repository: "UniversalStandards/atlantis-ai-enhanced",
+    baseRevision: "abc123",
+    configurationDigest: "sha256:configuration",
+    credentialClass: "non-secret-classification-only",
+    networkBoundary: "documented-non-production-boundary",
+    verificationGates: "typecheck; regression; security; follow-up-evaluation; immutable-proposal",
+    decisionEvidence: "candidate-record-and-authoritative-references",
+    approvalIdentities: {
+      architecture: "architecture-owner",
+      operations: "operations-owner",
+      "security-network": "security-owner",
+    },
+  } as const;
+}
+
 describe("self-improvement operational candidate authorization", () => {
   it("admits complete non-production evidence with no prohibited authority", () => {
     const result = validateSelfImprovementOperationalCandidateAuthorization(candidate());
@@ -45,6 +64,13 @@ describe("self-improvement operational candidate authorization", () => {
     expect(result.authorityBoundary).toBe("no-prohibited-authority");
     expect(Object.isFrozen(result)).toBe(true);
     expect(Object.isFrozen(result.approvals)).toBe(true);
+  });
+
+  it("binds admission to independently supplied candidate, base, config, verification, network, credential, decision, and approver identities", () => {
+    const result = authorizeSelfImprovementOperationalCandidateAdmission(candidate(), expectedAdmission());
+    expect(result.baseRevision).toBe(expectedAdmission().baseRevision);
+    expect(result.configurationDigest).toBe(expectedAdmission().configurationDigest);
+    expect(result.verificationGates).toBe(expectedAdmission().verificationGates);
   });
 
   it("rejects production or default-enabled candidates", () => {
@@ -62,7 +88,36 @@ describe("self-improvement operational candidate authorization", () => {
     expect(() => validateSelfImprovementOperationalCandidateAuthorization({ ...candidate(), approvals: candidate().approvals.map((approval, index) => index === 0 ? { ...approval, approvedAt: "2026-08-28" } : approval) })).toThrow(/canonical ISO timestamp/);
   });
 
-  it("rejects unsupported fields so secret-bearing runtime material cannot enter the record", () => {
+  it("rejects missing required decisions and unsupported fields", () => {
+    const { timeoutCancellationMechanism: _missing, ...missingDecision } = candidate();
+    expect(() => validateSelfImprovementOperationalCandidateAuthorization(missingDecision)).toThrow(/timeoutCancellationMechanism/);
     expect(() => validateSelfImprovementOperationalCandidateAuthorization({ ...candidate(), token: "must-not-be-recorded" })).toThrow(/unsupported field/);
+  });
+
+  it.each([
+    ["baseRevision", { baseRevision: "substituted-base" }, /baseRevision does not match/],
+    ["configurationDigest", { configurationDigest: "sha256:substituted" }, /configurationDigest does not match/],
+    ["verificationGates", { verificationGates: "caller-supplied-pass" }, /verificationGates does not match/],
+    ["networkBoundary", { networkBoundary: "expanded-network" }, /networkBoundary does not match/],
+    ["credentialClass", { credentialClass: "expanded-credential-class" }, /credentialClass does not match/],
+    ["decisionEvidence", { decisionEvidence: "substituted-decision" }, /decisionEvidence does not match/],
+  ])("rejects substituted %s admission evidence", (_field, mutation, message) => {
+    expect(() => authorizeSelfImprovementOperationalCandidateAdmission({ ...candidate(), ...mutation }, expectedAdmission())).toThrow(message);
+  });
+
+  it("rejects substituted approval identity", () => {
+    const substituted = {
+      ...candidate(),
+      approvals: candidate().approvals.map((approval) => approval.role === "security-network"
+        ? { ...approval, approvedBy: "different-security-actor" }
+        : approval),
+    };
+    expect(() => authorizeSelfImprovementOperationalCandidateAdmission(substituted, expectedAdmission())).toThrow(/security-network approval identity does not match/);
+  });
+
+  it("rejects incomplete or secret-bearing expected admission records", () => {
+    const { networkBoundary: _missing, ...missingExpected } = expectedAdmission();
+    expect(() => authorizeSelfImprovementOperationalCandidateAdmission(candidate(), missingExpected)).toThrow(/networkBoundary/);
+    expect(() => authorizeSelfImprovementOperationalCandidateAdmission(candidate(), { ...expectedAdmission(), token: "must-not-be-recorded" })).toThrow(/unsupported field/);
   });
 });


### PR DESCRIPTION
Closes #25

## Scope
Extends the existing self-improvement operational candidate authorization contract; it does not introduce a new runtime, provider selection, credential path, or parallel approval model.

- binds candidate/repository/base/configuration/verification/network/credential/decision evidence to independently supplied expected values;
- binds architecture, operations, and security-network approver identities to trusted expectations;
- reuses `validateSelfImprovementOperationalCandidateAuthorization` as the structural gate;
- adds deterministic fail-closed tests for missing required decisions and substituted base/configuration/verification/network/credential/decision/approval identities;
- introduces no shell, process, worktree, network, credential, merge, deployment, or production-mutation execution.

## Ancestry
Base integration HEAD at branch creation: `bef69696135ef3d7ff0bee0fa6e5f4b82bef1ba9`
Focused head: `8300dfea12347733aff677e3d5c9042c64c709e1`

## Verification required before integration
- exact diff/ancestry review;
- contracts typecheck/tests and existing self-improvement suites;
- Universal Standards Conformance;
- applicable CodeQL and Socket evidence;
- post-integration canonical-head verification before #25 closes.

Parent #7 remains open for the separately authorized real isolated-development run ending at `awaiting-human-review`.